### PR TITLE
Add a catch-all handler 2nd version

### DIFF
--- a/include/crow/app.h
+++ b/include/crow/app.h
@@ -347,7 +347,13 @@ namespace crow
                 return;
             cv_started_.wait(lock);
         }
-
+#ifdef CROW_CATCHALL
+    public:
+        void catchall_handler( catch_all_func_t func )
+        {
+            router_.set_catchall( func );
+        }
+#endif
     private:
         uint16_t port_ = 80;
         uint16_t concurrency_ = 1;

--- a/include/crow/example_catchall.cpp
+++ b/include/crow/example_catchall.cpp
@@ -1,0 +1,50 @@
+// compile with g++ example_catchall.cpp -lpthread -lz -I../crow
+
+#define CROW_CATCHALL
+#define CROW_MAIN
+#include <crow.h>
+
+
+void catch_all_func( const crow::request& req_crow, crow::response& res_crow )
+{
+    res_crow.body = "No action found for url: '" + req_crow.raw_url + "'!";
+    res_crow.code = 404;
+}
+
+
+
+class Catcher
+{
+public:
+    void catch_all_member( const crow::request& req_crow, crow::response& res_crow )
+    {
+        catch_all_func( req_crow, res_crow );
+    }
+
+    static void catch_all_static( const crow::request& req_crow, crow::response& res_crow )
+    {
+        catch_all_func( req_crow, res_crow );
+    }
+
+};
+
+
+
+int main()
+{
+    crow::SimpleApp app;
+
+#if 1 // use member function
+    using namespace std::placeholders;
+    Catcher c;
+    crow::catch_all_func_t fn = std::bind( &Catcher::catch_all_member, c, _1, _2);
+    app.catchall_handler( fn );
+#elif 1 // use static class function
+    app.catchall_handler( Catcher::catch_all_static );
+#else // use ordinary function
+    app.catchall_handler( catch_all_func );
+#endif
+
+    app.port( 12345 ).run();
+    return 0;
+}

--- a/include/crow/routing.h
+++ b/include/crow/routing.h
@@ -934,6 +934,9 @@ namespace crow
         std::vector<Node> nodes_;
     };
 
+#ifdef CROW_CATCHALL
+    using catch_all_func_t= std::function<void( const crow::request& , crow::response& )>;
+#endif
     /// Handles matching requests to existing rules and upgrade requests.
     class Router
     {
@@ -1158,10 +1161,18 @@ namespace crow
                         return;
                     }
                 }
-
-                CROW_LOG_DEBUG << "Cannot match rules " << req.url;
-                res = response(404);
+#ifdef CROW_CATCHALL
+                if ( catch_all_handler_ )
+                {
+                    catch_all_handler_( req, res );
+                }
+                else
+                {
+                    CROW_LOG_DEBUG << "Cannot match rules " << req.url;
+                    res = response(404);
+                }
                 res.end();
+#endif
                 return;
             }
 
@@ -1218,6 +1229,15 @@ namespace crow
             }
         }
 
+#ifdef CROW_CATCHALL
+    public:
+        void set_catchall( catch_all_func_t func)
+        {
+            catch_all_handler_ = func;
+        }
+    private:
+        catch_all_func_t catch_all_handler_;
+#endif
     private:
         struct PerMethod
         {
@@ -1229,5 +1249,6 @@ namespace crow
         };
         std::array<PerMethod, static_cast<int>(HTTPMethod::InternalMethodCount)> per_methods_;
         std::vector<std::unique_ptr<BaseRule>> all_rules_;
+
     };
 }


### PR DESCRIPTION
Here is the modified catchall-function
example added
the code moved to routing.h
only the setter remained in app.h
the integer return is removed
i personally don't need the default parameters:
without crow::response the catchall can take no effect
and without crow::request you know nothing about the request
i only imagine one case, this is to set custom error pages.
so i don't thing default parameters have any big benefit here.
"#ifdef CROW_CATCHALL" was only for me, to find my own modifications feel free to replace it